### PR TITLE
Fixed compile error

### DIFF
--- a/ResponseContent.cs
+++ b/ResponseContent.cs
@@ -10,18 +10,19 @@ namespace Sample.ExternalIdentities
             this.action = "Continue";
         }
 
-        public ResponseContent(string action, string userMessage, string status='')
+        public ResponseContent(string action, string userMessage, string status="")
         {
             this.version = ResponseContent.ApiVersion;
             this.action = action;
             this.userMessage = userMessage;
-            if(status=='400'){
-                this.status = '400'
+            if(status=="400"){
+                this.status = "400";
             }
         }
 
         public string version { get; }
         public string action { get; set; }
         public string userMessage { get; set; }
+        public string status { get; set; }
     }
 }


### PR DESCRIPTION
I opened issue #1, this request fixes compilation errors by converting from character literals to strings where appropriate (line 13, 18, 19). Added a missing semicolin to like 19. Added the status string to the class definition in line 26. This class now successfully compiles on DotNet 3.1.301, I'm not sure if it was successfully compiling on older version or not, but I can't imagine it was.