### PR TITLE
Fix to ShowBlockPage response

### DIFF
--- a/ResponseContent.cs
+++ b/ResponseContent.cs
@@ -1,3 +1,5 @@
+using Newtonsoft.Json;
+
 namespace Sample.ExternalIdentities
 {
     public class ResponseContent
@@ -15,7 +17,7 @@ namespace Sample.ExternalIdentities
             this.version = ResponseContent.ApiVersion;
             this.action = action;
             this.userMessage = userMessage;
-            if (action != "Continue")
+            if (action == "ValidationError")
             {
                 this.status = "400";
             }
@@ -24,6 +26,8 @@ namespace Sample.ExternalIdentities
         public string version { get; }
         public string action { get; set; }
         public string userMessage { get; set; }
+        
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string status { get; set; }
     }
 }

--- a/SignUpValidation.cs
+++ b/SignUpValidation.cs
@@ -48,7 +48,7 @@ namespace Sample.ExternalIdentities
             // If email claim not found, show block page. Email is required and sent by default.
             if (data.email == null || data.email.ToString() == "" || data.email.ToString().Contains("@") == false)
             {
-                return (ActionResult)new BadRequestObjectResult(new ResponseContent("ShowBlockPage", "Email name is mandatory."));
+                return (ActionResult)new OkObjectResult(new ResponseContent("ShowBlockPage", "Email name is mandatory."));
             }
 
             // Get domain of email address
@@ -57,7 +57,7 @@ namespace Sample.ExternalIdentities
             // Check the domain in the allowed list
             if (!allowedDomain.Contains(domain.ToLower()))
             {
-                return (ActionResult)new BadRequestObjectResult(new ResponseContent("ShowBlockPage", $"You must have an account from '{string.Join(", ", allowedDomain)}' to register as an external user for Contoso."));
+                return (ActionResult)new OkObjectResult(new ResponseContent("ShowBlockPage", $"You must have an account from '{string.Join(", ", allowedDomain)}' to register as an external user for Contoso."));
             }
 
             // If jobTitle claim doesn't exist, or it is too short, show validation error message. So, user can fix the input data.


### PR DESCRIPTION
In this PR:

- When the app returns `ShowBlockPage`, the HTTP status is 200, instead of 400.
- When the app returns `ShowBlockPage`, json response `status` is null
- `ResponseContent` JSON serialization doesn't output the status when null.

Yoel
