### PR TITLE
Update responce ApiVersion and added a couple of comments illustrating returning custom claims

### DIFF
--- a/ResponseContent.cs
+++ b/ResponseContent.cs
@@ -4,7 +4,7 @@ namespace Sample.ExternalIdentities
 {
     public class ResponseContent
     {
-        public const string ApiVersion = "0.0.1";
+        public const string ApiVersion = "1.0.0";
 
         public ResponseContent()
         {
@@ -25,11 +25,20 @@ namespace Sample.ExternalIdentities
 
         public string version { get; }
         public string action { get; set; }
+
+
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string userMessage { get; set; }
+
+
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string status { get; set; }
+
+
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string jobTitle { get; set; }
+
+        //[JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        //public string extension_CustomClaim { get; set; }
     }
 }

--- a/SignUpValidation.cs
+++ b/SignUpValidation.cs
@@ -67,9 +67,11 @@ namespace Sample.ExternalIdentities
             }
 
             // Input validation passed successfully, return `Allow` response.
-            // TO DO: Configure the claims you want to return 
+            // TO DO: Configure the claims you want to return
             return (ActionResult)new OkObjectResult(new ResponseContent() { 
-                jobTitle = "This value return by the API Connector" 
+                jobTitle = "This value return by the API Connector"//,
+                // You can also return custom claims using extension properties.
+                //extension_CustomClaim = "my custom claim response"
             });
         }
 


### PR DESCRIPTION
Changes:

- Current Response ApiVersion is now "1.0.0", I've updated the sample to reflect that.
- Added a couple of comments illustrating the way a user can use the sample to return custom claims. I've struggled with it because documentation wasn't clear so I thought it would be helpful to someone like myself.